### PR TITLE
Test for woocommerce installation before attempting anything

### DIFF
--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -15,7 +15,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'WC_Beta_Tester' ) ) :
+/**
+ * Confirm woocommerce is at least installed before doing anything
+ * Curiously, developers are discouraged from using WP_PLUGIN_DIR and not given a
+ * function with which to get the plugin directory, so this is what we have to do
+ */
+if ( ! file_exists( trailingslashit( dirname( dirname( __FILE__ ) ) ) . 'woocommerce/woocommerce.php' ) ) :
+
+	add_action( 'admin_notices', 'wcbt_woocoommerce_not_installed' );
+
+elseif ( ! class_exists( 'WC_Beta_Tester' ) ) :
 
 	/**
 	 * WC_Beta_Tester Main Class
@@ -281,3 +290,17 @@ if ( ! class_exists( 'WC_Beta_Tester' ) ) :
 	add_action( 'admin_init', array( 'WC_Beta_Tester', 'instance' ) );
 
 endif;
+
+
+/**
+* WooCommerce Not Installed Notice
+**/
+if ( ! function_exists( 'wcbt_woocoommerce_not_installed' ) ) {
+
+	function wcbt_woocoommerce_not_installed() {
+
+		echo '<div class="error"><p>' . sprintf( __( 'WooCommerce Beta Tester requires %s to be installed.', 'woocommerce-beta-tester' ), '<a href="http://www.woothemes.com/woocommerce/" target="_blank">WooCommerce</a>' ) . '</p></div>';
+
+	}
+
+}


### PR DESCRIPTION
Fixes #3 

To test
1. Set WP_DEBUG to true if not already done so
2. Deactivate and uninstall woocommerce if present
3. Install this plugin and activate it
4. Ensure no errors occur
5. Verify you get an admin notice that prompts you to install woocommerce
6. Install woocommerce from the org repo
7. Verify the admin notice goes away
8. Verify you are immediately prompted to accept a beta release of woocommerce (e.g. 2.4.0-beta-3)
9. Verify you are able to update
10. Verify no errors in error_log or wp-admin/error_log
