### PR TITLE
Use WordPress.org for downloading WooCommerce

### DIFF
--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -112,8 +112,7 @@ class WC_Beta_Tester {
 			$versions       = (array) $data->versions;
 
 			foreach ( $versions as $version => $download_url ) {
-				if ( version_compare( $version, $latest_version, '>' )
-					&& preg_match( '/(.*)?-(beta|rc)(.*)/', $version ) ) {
+				if ( preg_match( '/(.*)?-(beta|rc)(.*)/', $version ) ) {
 					$tagged_version = $version;
 				}
 			}

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -68,7 +68,7 @@ class WC_Beta_Tester {
 	 * Include any classes we need within admin.
 	 */
 	public function includes() {
-		include_once( dirname( __FILE__ ) . '/class-wc-beta-tester-admin-menus.php' );
+		include_once dirname( __FILE__ ) . '/class-wc-beta-tester-admin-menus.php';
 	}
 
 	/**
@@ -190,19 +190,19 @@ class WC_Beta_Tester {
 
 		$data = $data->sections->description;
 
-		if ( preg_match('%(<p[^>]*>.*?</p>)%i', $data, $regs ) ) {
+		if ( preg_match( '%(<p[^>]*>.*?</p>)%i', $data, $regs ) ) {
 			$data = strip_tags( $regs[1] );
 		}
-
 
 		return $data;
 	}
 
 	/**
-	 * Get plugin download URL
+	 * Get plugin download URL.
 	 *
 	 * @since 1.0
-	 * @return string $description the description
+	 * @param string $version The version.
+	 * @return string
 	 */
 	public function get_download_url( $version ) {
 		$data = $this->get_wporg_data();

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -74,7 +74,7 @@ class WC_Beta_Tester {
 		$this->config['new_version']  = $this->get_latest_prerelease();
 		$this->config['last_updated'] = $this->get_date();
 		$this->config['description']  = $this->get_description();
-		$this->config['zip_url']      = 'https://downloads.wordpress.org/plugin/woocommerce.' . $this->config['new_version'] . '.zip';
+		$this->config['zip_url']      = $this->get_download_url( $this->config['new_version'] );
 	}
 
 	/**
@@ -162,8 +162,8 @@ class WC_Beta_Tester {
 	 * @return string $date the date
 	 */
 	public function get_date() {
-		$_date = $this->get_wporg_data();
-		return ! empty( $_date->last_updated ) ? date( 'Y-m-d', strtotime( $_date->last_updated ) ) : false;
+		$data = $this->get_wporg_data();
+		return ! empty( $data->last_updated ) ? date( 'Y-m-d', strtotime( $data->last_updated ) ) : false;
 	}
 
 	/**
@@ -173,20 +173,36 @@ class WC_Beta_Tester {
 	 * @return string $description the description
 	 */
 	public function get_description() {
-		$_description = $this->get_wporg_data();
+		$data = $this->get_wporg_data();
 
-		if ( empty( $_description->sections->description ) ) {
+		if ( empty( $data->sections->description ) ) {
 			return false;
 		}
 
-		$_description = $_description->sections->description;
+		$data = $data->sections->description;
 
-		if ( preg_match('%(<p[^>]*>.*?</p>)%i', $_description, $regs ) ) {
-			$_description = strip_tags( $regs[1] );
+		if ( preg_match('%(<p[^>]*>.*?</p>)%i', $data, $regs ) ) {
+			$data = strip_tags( $regs[1] );
 		}
 
 
-		return $_description;
+		return $data;
+	}
+
+	/**
+	 * Get plugin download URL
+	 *
+	 * @since 1.0
+	 * @return string $description the description
+	 */
+	public function get_download_url( $version ) {
+		$data = $this->get_wporg_data();
+
+		if ( empty( $data->versions->$version ) ) {
+			return false;
+		}
+
+		return $data->versions->$version;
 	}
 
 	/**

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -52,7 +52,7 @@ class WC_Beta_Tester {
 			'slug'               => 'woocommerce',
 			'proper_folder_name' => 'woocommerce',
 			'api_url'            => 'https://api.wordpress.org/plugins/info/1.0/woocommerce.json',
-			'github_url'         => 'https://github.com/woocommerce/woocommerce',
+			'repo_url'           => 'https://wordpress.org/plugins/woocommerce/',
 			'requires'           => '4.4',
 			'tested'             => '4.9',
 		);
@@ -252,7 +252,7 @@ class WC_Beta_Tester {
 			$response->plugin      = $this->config['slug'];
 			$response->new_version = $this->config['new_version'];
 			$response->slug        = $this->config['slug'];
-			$response->url         = $this->config['github_url'];
+			$response->url         = $this->config['repo_url'];
 			$response->package     = $this->config['zip_url'];
 
 			// If response is false, don't alter the transient.

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -74,7 +74,7 @@ class WC_Beta_Tester {
 		$this->config['new_version']  = $this->get_latest_prerelease();
 		$this->config['last_updated'] = $this->get_date();
 		$this->config['description']  = $this->get_description();
-		$this->config['zip_url']      = 'https://github.com/woocommerce/woocommerce/zipball/' . $this->config['new_version'];
+		$this->config['zip_url']      = 'https://downloads.wordpress.org/plugin/woocommerce.' . $this->config['new_version'] . '.zip';
 	}
 
 	/**

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -106,21 +106,17 @@ class WC_Beta_Tester {
 
 		if ( $this->overrule_transients() || empty( $tagged_version ) ) {
 
-			$raw_response = wp_remote_get( trailingslashit( $this->config['api_url'] ) . 'releases' );
+			$data = $this->get_wporg_data();
 
-			if ( is_wp_error( $raw_response ) ) {
-				return false;
-			}
+			$latest_version = $data->version;
+			$versions       = (array) $data->versions;
 
-			$releases       = json_decode( $raw_response['body'] );
-			$tagged_version = false;
+			foreach ( $versions as $version => $download_url ) {
+				if ( version_compare( $version, $latest_version, '>' )
+					&& preg_match( '/(.*)?-(beta|rc)(.*)/', $version ) ) {
 
-			if ( is_array( $releases ) ) {
-				foreach ( $releases as $release ) {
-					if ( $release->prerelease ) {
-						$tagged_version = $release->tag_name;
-						break;
-					}
+					$tagged_version = $version;
+					break;
 				}
 			}
 

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -114,9 +114,7 @@ class WC_Beta_Tester {
 			foreach ( $versions as $version => $download_url ) {
 				if ( version_compare( $version, $latest_version, '>' )
 					&& preg_match( '/(.*)?-(beta|rc)(.*)/', $version ) ) {
-
 					$tagged_version = $version;
-					break;
 				}
 			}
 


### PR DESCRIPTION
With these changes, here's an example of how `zip_url` might look like:
```
- Eval of: '$this->config['zip_url']'

 ⬦ $this->config['zip_url'] = (string [65]) `https://downloads.wordpress.org/plugin/woocommerce.3.4.0-rc.2.zip`
```

We just need to make sure tags on .org are matching the names on GitHub.