### PR TITLE
Display notices to install and enable WooCommerce

### DIFF
--- a/includes/class-wc-beta-tester-admin-notices.php
+++ b/includes/class-wc-beta-tester-admin-notices.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Admin notices
+ *
+ * @package WC_Beta_Tester\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin notices class.
+ */
+class WC_Beta_Tester_Admin_Notices {
+
+	/**
+	 * WooCommerce not installed notice.
+	 */
+	public function woocoommerce_not_installed() {
+		include_once dirname( __FILE__ ) . '/views/html-admin-missing-woocommerce.php';
+	}
+}

--- a/includes/views/html-admin-missing-woocommerce.php
+++ b/includes/views/html-admin-missing-woocommerce.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Missing WooCommerce notice.
+ *
+ * @package WC_Beta_Tester\Admin\Views
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+
+<div class="notice notice-error">
+	<p><strong><?php esc_html_e( 'WooCommerce Beta Tester', 'woocommerce-beta-tester' ); ?></strong> <?php esc_html_e( 'requires WooCommerce to be installed and enabled.', 'woocommerce-beta-tester' ); ?></p>
+
+	<?php if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) && current_user_can( 'activate_plugin', 'woocommerce/woocommerce.php' ) ) : ?>
+		<p>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce/woocommerce.php&plugin_status=active' ), 'activate-plugin_woocommerce/woocommerce.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Active WooCommerce', 'woocommerce-beta-tester' ); ?></a>
+			<?php if ( current_user_can( 'deactivate_plugin', 'woocommerce-beta-tester/woocommerce-beta-tester.php' ) ) : ?>
+				<a href="<?php echo esc_url( wp_nonce_url( 'plugins.php?action=deactivate&plugin=woocommerce-beta-tester/woocommerce-beta-tester.php&plugin_status=inactive', 'deactivate-plugin_woocommerce-beta-tester/woocommerce-beta-tester.php' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Turn off Beta Tester plugin', 'woocommerce-beta-tester' ); ?></a>
+			<?php endif; ?>
+		</p>
+	<?php else : ?>
+		<?php
+		if ( current_user_can( 'install_plugins' ) ) {
+			$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce' ), 'install-plugin_woocommerce' );
+		} else {
+			$url = 'http://wordpress.org/plugins/woocommerce/';
+		}
+		?>
+		<p>
+			<a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install WooCommerce', 'woocommerce-beta-tester' ); ?></a>
+			<?php if ( current_user_can( 'deactivate_plugin', 'woocommerce-beta-tester/woocommerce-beta-tester.php' ) ) : ?>
+				<a href="<?php echo esc_url( wp_nonce_url( 'plugins.php?action=deactivate&plugin=woocommerce-beta-tester/woocommerce-beta-tester.php&plugin_status=inactive', 'deactivate-plugin_woocommerce-beta-tester/woocommerce-beta-tester.php' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Turn off Beta Tester plugin', 'woocommerce-beta-tester' ); ?></a>
+			<?php endif; ?>
+		</p>
+	<?php endif; ?>
+</div>

--- a/includes/views/html-admin-missing-woocommerce.php
+++ b/includes/views/html-admin-missing-woocommerce.php
@@ -10,7 +10,12 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <div class="notice notice-error">
-	<p><strong><?php esc_html_e( 'WooCommerce Beta Tester', 'woocommerce-beta-tester' ); ?></strong> <?php esc_html_e( 'requires WooCommerce to be installed and enabled.', 'woocommerce-beta-tester' ); ?></p>
+	<p>
+		<?php
+		// Translators: %s Plugin name.
+		echo sprintf( esc_html__( '%s requires WooCommerce to be installed and activated in order to serve updates.', 'woocommerce-beta-tester' ), '<strong>' . esc_html__( 'WooCommerce Beta Tester', 'woocommerce-beta-tester' ) . '</strong>' );
+		?>
+	</p>
 
 	<?php if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) && current_user_can( 'activate_plugin', 'woocommerce/woocommerce.php' ) ) : ?>
 		<p>

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -8,7 +8,6 @@
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4
  * Tested up to: 4.9
- *
  * Text Domain: woocommerce-beta-tester
  *
  * @package WC_Beta_Tester
@@ -17,29 +16,36 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Confirm woocommerce is at least installed before doing anything
- * Curiously, developers are discouraged from using WP_PLUGIN_DIR and not given a
- * function with which to get the plugin directory, so this is what we have to do.
+ * Load text domain before all other code.
+ *
+ * @since 2.0.0
  */
-if ( ! file_exists( trailingslashit( dirname( dirname( __FILE__ ) ) ) . 'woocommerce/woocommerce.php' ) ) {
-	if ( ! function_exists( 'wcbt_woocoommerce_not_installed' ) ) {
-
-		/**
-		 * WooCommerce Not Installed Notice.
-		 */
-		function wcbt_woocoommerce_not_installed() {
-			/* translators: %s: woocommerce url */
-			echo '<div class="error"><p>' . wp_kses_post( sprintf( __( 'WooCommerce Beta Tester requires %s to be installed.', 'woocommerce-beta-tester' ), '<a href="http://www.woocommerce.com/" target="_blank">WooCommerce</a>' ) ) . '</p></div>';
-		}
-	}
-
-	add_action( 'admin_notices', 'wcbt_woocoommerce_not_installed' );
-} elseif ( ! class_exists( 'WC_Beta_Tester' ) ) {
-	include dirname( __FILE__ ) . '/includes/class-wc-beta-tester.php';
-	// Settings.
-	include dirname( __FILE__ ) . '/includes/class-wc-beta-tester-settings.php';
-
-	register_activation_hook( __FILE__, array( 'WC_Beta_Tester', 'activate' ) );
-
-	add_action( 'admin_init', array( 'WC_Beta_Tester', 'instance' ) );
+function _wc_beta_tester_load_textdomain() {
+	load_plugin_textdomain( 'woocommerce-beta-tester', false, basename( dirname( __FILE__ ) ) . '/languages' );
 }
+
+add_action( 'plugins_loaded', '_wc_beta_tester_load_textdomain' );
+
+/**
+ * Boostrap plugin.
+ */
+function _wc_beta_tester_bootstrap() {
+
+	// Check if WooCommerce is enabled.
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		include dirname( __FILE__ ) . '/includes/class-wc-beta-tester-admin-notices.php';
+		$notices = new WC_Beta_Tester_Admin_Notices();
+
+		add_action( 'admin_notices', array( $notices, 'woocoommerce_not_installed' ) );
+	} elseif ( ! class_exists( 'WC_Beta_Tester' ) ) {
+		include dirname( __FILE__ ) . '/includes/class-wc-beta-tester.php';
+		// Settings.
+		include dirname( __FILE__ ) . '/includes/class-wc-beta-tester-settings.php';
+
+		register_activation_hook( __FILE__, array( 'WC_Beta_Tester', 'activate' ) );
+
+		add_action( 'admin_init', array( 'WC_Beta_Tester', 'instance' ) );
+	}
+}
+
+add_action( 'plugins_loaded', '_wc_beta_tester_bootstrap' );


### PR DESCRIPTION
Closes #18 

Steps to test:

1. Uninstall WooCommerce.
2. Enable Beta Tester in plugin's admin screen.
3. Click to install WooCommerce in the new notice.
4. Click to disable Beta Tester in the new notice.
5. Enable Beta Tester again in plugin's admin screen.
6. Enable WooCommerce in the new notice.