### PR TITLE
Auto updates

### DIFF
--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -138,20 +138,17 @@ class WC_Beta_Tester_Admin_Menus {
 			'title'  => __( 'WC Beta Tester', 'woocommerce-beta-tester' ),
 		) );
 
-		$current_channel = __( 'Stable', 'woocommerce-beta-tester' );
-		$options         = get_option( 'wc_beta_tester_options' );
-		if ( isset( $options['wc-beta-tester-version'] ) ) {
-			switch ( $options['wc-beta-tester-version'] ) {
-				case 'beta':
-					$current_channel = __( 'Beta', 'woocommerce-beta-tester' );
-					break;
-				case 'rc':
-					$current_channel = __( 'Release Candidate', 'woocommerce-beta-tester' );
-					break;
-				default:
-					$current_channel = __( 'Stable', 'woocommerce-beta-tester' );
-					break;
-			}
+		$settings = WC_Beta_Tester::get_settings();
+		switch ( $settings->channel ) {
+			case 'beta':
+				$current_channel = __( 'Beta', 'woocommerce-beta-tester' );
+				break;
+			case 'rc':
+				$current_channel = __( 'Release Candidate', 'woocommerce-beta-tester' );
+				break;
+			default:
+				$current_channel = __( 'Stable', 'woocommerce-beta-tester' );
+				break;
 		}
 
 		// TODO: Implementation of each node.

--- a/includes/class-wc-beta-tester-settings.php
+++ b/includes/class-wc-beta-tester-settings.php
@@ -34,13 +34,24 @@ class WC_Beta_Tester_Settings {
 		);
 
 		add_settings_field(
-			'wc-beta-tester-version',
+			'wc-beta-tester-channel',
 			__( 'Release Channel', 'woocommerce-beta-tester' ),
 			array( $this, 'version_select_html' ),
 			'wc-beta-tester',
 			'wc-beta-tester-update',
 			array(
-				'label_for' => 'wc-beta-tester-version',
+				'label_for' => 'channel',
+			)
+		);
+
+		add_settings_field(
+			'wc-beta-tester-auto-update',
+			__( 'Automatic Updates', 'woocommerce-beta-tester' ),
+			array( $this, 'automatic_update_checkbox_html' ),
+			'wc-beta-tester',
+			'wc-beta-tester-update',
+			array(
+				'label_for' => 'auto_update',
 			)
 		);
 	}
@@ -57,13 +68,12 @@ class WC_Beta_Tester_Settings {
 	}
 
 	/**
-	 * Version select markup output
+	 * Version select markup output.
 	 *
 	 * @param array $args Arguments.
 	 */
 	public function version_select_html( $args ) {
-		$options  = get_option( 'wc_beta_tester_options' );
-		$selected = isset( $options[ $args['label_for'] ] ) ? $options[ $args['label_for'] ] : 'stable';
+		$settings = WC_Beta_Tester::get_settings();
 		$channels = array(
 			'beta' => array(
 				'name'        => __( 'Beta Releases', 'woocommerce-beta-tester' ),
@@ -82,7 +92,7 @@ class WC_Beta_Tester_Settings {
 		foreach ( $channels as $channel_id => $channel ) {
 			?>
 			<label>
-				<input type="radio" id="<?php echo esc_attr( $args['label_for'] ); ?>" name="wc_beta_tester_options[<?php echo esc_attr( $args['label_for'] ); ?>]" value="<?php echo esc_attr( $channel_id ); ?>" <?php checked( $selected, $channel_id ); ?> />
+				<input type="radio" id="<?php echo esc_attr( $args['label_for'] ); ?>" name="wc_beta_tester_options[<?php echo esc_attr( $args['label_for'] ); ?>]" value="<?php echo esc_attr( $channel_id ); ?>" <?php checked( $settings->{ $args['label_for'] }, $channel_id ); ?> />
 				<?php echo esc_html( $channel['name'] ); ?>
 				<p class="description">
 					<?php echo esc_html( $channel['description'] ); ?>
@@ -92,6 +102,21 @@ class WC_Beta_Tester_Settings {
 			<?php
 		}
 		echo '</fieldset>';
+	}
+
+	/**
+	 * Auto updates checkbox markup output.
+	 *
+	 * @param array $args Arguments.
+	 */
+	public function automatic_update_checkbox_html( $args ) {
+		$settings = WC_Beta_Tester::get_settings();
+		?>
+		<label for="<?php echo esc_attr( $args['label_for'] ); ?>">
+			<input type="checkbox" id="<?php echo esc_attr( $args['label_for'] ); ?>" name="wc_beta_tester_options[<?php echo esc_attr( $args['label_for'] ); ?>]" value="1" <?php checked( $settings->{ $args['label_for'] }, true ); ?> />
+			<?php echo esc_html__( 'If enabled, WooCommerce will update to the latest release in the background. Use with caution; we do not recommend using this on production stores!', 'woocommerce-beta-tester' ); ?>
+		</label>
+		<?php
 	}
 
 	/**
@@ -109,7 +134,7 @@ class WC_Beta_Tester_Settings {
 			return;
 		}
 
-		if ( isset( $_GET['settings-updated'] ) ) {
+		if ( isset( $_GET['settings-updated'] ) ) { // WPCS: input var.
 			add_settings_error( 'wc-beta-tester-messages', 'wc-beta-tester-message', __( 'Settings Saved', 'woocommerce-beta-tester' ), 'updated' );
 		}
 

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -86,6 +86,7 @@ class WC_Beta_Tester {
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );
 		add_filter( 'plugins_api', array( $this, 'get_plugin_info' ), 10, 3 );
 		add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 3 );
+		add_filter( 'auto_update_plugin', 'auto_update_woocommerce', 100, 2 );
 
 		$this->includes();
 	}
@@ -341,6 +342,21 @@ class WC_Beta_Tester {
 		}
 
 		return $source;
+	}
+
+	/**
+	 * Enable auto updates for WooCommerce.
+	 *
+	 * @param bool   $update Should this autoupdate.
+	 * @param object $plugin Plugin being checked.
+	 * @return bool
+	 */
+	public function auto_update_woocommerce( $update, $plugin ) {
+		if ( true === $this->get_settings()->auto_update && 'woocommerce' === $item->slug ) {
+			return true;
+		} else {
+			return $update;
+		}
 	}
 
 	/**

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -44,6 +44,23 @@ class WC_Beta_Tester {
 	}
 
 	/**
+	 * Get plugin settings.
+	 *
+	 * @return object
+	 */
+	public static function get_settings() {
+		$settings = (object) wp_parse_args(
+			get_option( 'wc_beta_tester_options', array() ),
+			array(
+				'channel'     => 'stable',
+				'auto_update' => false,
+			)
+		);
+		$settings->auto_update = (bool) $settings->auto_update;
+		return $settings;
+	}
+
+	/**
 	 * Get the plugin url.
 	 *
 	 * @return string
@@ -329,7 +346,7 @@ class WC_Beta_Tester {
 	/**
 	 * Gets release information from GitHub.
 	 *
-	 * @param string $version
+	 * @param string $version Version number.
 	 * @return bool|string False on error, description otherwise
 	 */
 	public function get_version_information( $version ) {


### PR DESCRIPTION
Introduces a setting to toggle auto updates on.

Priority 100 is used to bypass WooCommerce core logic which disables this explicitly.

Closes #34