### PR TITLE
Don't make external requests

### DIFF
--- a/includes/class-wc-beta-tester-admin-assets.php
+++ b/includes/class-wc-beta-tester-admin-assets.php
@@ -38,7 +38,8 @@ class WC_Beta_Tester_Admin_Assets {
 			'wc_beta_tester_version_info_params',
 			array(
 				'version'     => $version,
-				'description' => WC_Beta_Tester::instance()->get_github_release_information( $version )->body,
+				/* translators: %s: Release version number */
+				'description' => sprintf( __( 'Release of version %s', 'woocommerce-beta-tester' ), $version ),
 			)
 		);
 

--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -28,13 +28,38 @@ class WC_Beta_Tester_Admin_Menus {
 	 * @return string
 	 */
 	protected function get_ticket_template() {
-		$bug_tpl = wp_remote_retrieve_body( wp_remote_get( 'https://raw.githubusercontent.com/woocommerce/woocommerce/master/.github/ISSUE_TEMPLATE/Bug_report.md' ) );
+		ob_start();
+		?>
+**Describe the bug**
+A clear and concise description of what the bug is. Please be as descriptive as possible; issues lacking detail, or for any other reason than to report a bug, may be closed without action.
 
-		$begin = strpos( $bug_tpl, '**Describe the bug**' );
-		if ( $begin ) {
-			$bug_tpl = substr( $bug_tpl, $begin );
-		}
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Isolating the problem (mark completed items with an [x]):**
+- [ ] I have deactivated other plugins and confirmed this bug occurs when only WooCommerce plugin is active.
+- [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/).
+- [ ] I can reproduce this bug consistently using the steps above.
+
+**WordPress Environment**
+<details>
+```
+Copy and paste the system status report from **WooCommerce > System Status** in WordPress admin.
+```
+</details>
+		<?php
+
+		$bug_tpl = ob_get_clean();
 		return $bug_tpl;
 	}
 

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -287,8 +287,6 @@ class WC_Beta_Tester {
 			return $response;
 		}
 
-		$github_release_data = $this->get_github_release_information( $new_version );
-
 		if ( $this->is_beta_version( $new_version ) ) {
 			$warning = __( '<h1><span>&#9888;</span>This is a beta release<span>&#9888;</span></h1>', 'woocommerce-beta-tester' );
 		}
@@ -301,10 +299,9 @@ class WC_Beta_Tester {
 		$response->version       = $new_version;
 		$response->download_link = $this->get_download_url( $new_version );
 
-		$response->sections['changelog']   = make_clickable( wpautop( $github_release_data->body ) );
-		$response->sections['changelog']  .= sprintf(
-			'<p><a target="_blank" href="%s">' . __( 'Read more on GitHub', 'woocommerce-beta-tester' ) . '</a></p>',
-			'https://github.com/woocommerce/woocommerce/releases/tag/' . $response->version
+		$response->sections['changelog'] = sprintf(
+			'<p><a target="_blank" href="%s">' . __( 'Read the changelog and find out more about the release on GitHub.', 'woocommerce-beta-tester' ) . '</a></p>',
+			'https://github.com/woocommerce/woocommerce/blob/' . $response->version . '/readme.txt'
 		);
 
 		foreach ( $response->sections as $key => $section ) {
@@ -351,40 +348,6 @@ class WC_Beta_Tester {
 		} else {
 			return $update;
 		}
-	}
-
-	/**
-	 * Gets release information from GitHub.
-	 *
-	 * @param string $version Version number.
-	 * @return bool|string False on error, description otherwise
-	 */
-	public function get_github_release_information( $version ) {
-		$url         = 'https: //api.github.com/repos/woocommerce/woocommerce/releases/tags/' . $version;
-		$github_data = get_site_transient( md5( $url ) . '_github_data' );
-
-		if ( $this->overrule_transients() || empty( $github_data ) ) {
-			$github_data = wp_remote_get( $url, array(
-				'sslverify' => false,
-			) );
-
-			if ( is_wp_error( $github_data ) ) {
-				return false;
-			}
-
-			$github_data = json_decode( $github_data['body'] );
-
-			if ( empty( $github_data ) ) {
-				return false;
-			}
-
-			$github_data = $github_data;
-
-			// Refresh every 6 hours.
-			set_site_transient( md5( $url ) . '_github_data', $github_data, HOUR_IN_SECONDS * 6 );
-		}
-
-		return $github_data;
 	}
 
 	/**

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -8,6 +8,8 @@
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4
  * Tested up to: 4.9
+ * WC requires at least: 3.0.0
+ * WC tested up to: 3.5.0
  * Text Domain: woocommerce-beta-tester
  *
  * @package WC_Beta_Tester


### PR DESCRIPTION
Closes #46 

This PR refactors some areas to make them not require external requests to GitHub:
- Hard-coded issue template
- Provide a link to the changelog instead of pulling the changelog from GitHub

As a side-benefit, the plugin is much more performant since it doesn't have to wait on external requests.

To test:
- Use the link to open a new bug report and verify everything works.
- Spoof a version [here](https://github.com/woocommerce/woocommerce-beta-tester/compare/fix/46?expand=1#diff-cb81ec969b6439d10dd8ddcf634fc418R284) and verify everything works and the link would generate a valid readme.txt URL.