### PR TITLE
Fix exception when running against master/3.6-dev

### DIFF
--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -16,7 +16,7 @@ class WC_Beta_Tester_Admin_Menus {
 	 * Constructor
 	 */
 	public function __construct() {
-		if ( class_exists( 'WC_Admin_Status' ) && class_exists( 'WC_REST_System_Status_Controller' ) ) {
+		if ( class_exists( 'WC_Admin_Status' ) ) {
 			add_action( 'admin_bar_menu', array( $this, 'admin_bar_menus' ), 50 );
 		}
 		add_action( 'admin_footer', array( $this, 'version_information_template' ) );
@@ -156,6 +156,14 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 		$ssr            = get_transient( $transient_name );
 
 		if ( false === $ssr ) {
+			if( ! did_action( 'rest_api_init' ) ) {
+				WC()->api->rest_api_includes();
+			}
+
+			if ( ! class_exists( 'WC_REST_System_Status_Controller', false ) ) {
+				return '';
+			}
+
 			// Get SSR.
 			$api      = new WC_REST_System_Status_Controller();
 			$schema   = $api->get_item_schema();

--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -16,7 +16,7 @@ class WC_Beta_Tester_Admin_Menus {
 	 * Constructor
 	 */
 	public function __construct() {
-		if ( class_exists( 'WC_Admin_Status' ) ) {
+		if ( class_exists( 'WC_Admin_Status' ) && class_exists( 'WC_REST_System_Status_Controller' ) ) {
 			add_action( 'admin_bar_menu', array( $this, 'admin_bar_menus' ), 50 );
 		}
 		add_action( 'admin_footer', array( $this, 'version_information_template' ) );


### PR DESCRIPTION
When running the latest master / 3.6-dev locally with this plugin installed, I was getting the following exception:

![exception](https://user-images.githubusercontent.com/22080/53908204-ac38e480-4003-11e9-9b0e-d93d0ca5c952.png)

This branch fixed the issue for me locally, but I'm unsure of _why_ the error was happening in the first place, but figured opening up a PR instead of an issue is always nice :)