### PR TITLE
Check WC version before calling WC_API::rest_api_includes()

### DIFF
--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -156,7 +156,8 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 		$ssr            = get_transient( $transient_name );
 
 		if ( false === $ssr ) {
-			if( ! did_action( 'rest_api_init' ) ) {
+			// When running WC 3.6 or greater it is necessary to manually load the REST API classes.
+			if ( version_compare( WC()->version, '3.6', '>=' ) && ! did_action( 'rest_api_init' ) ) {
 				WC()->api->rest_api_includes();
 			}
 


### PR DESCRIPTION
When running WC 3.6 or greater it is necessary to call WC_API::rest_api_includes() to manually load the WC REST API classes. The problem is that this method was private before WC 3.6, so this commit adds a check to only call WC_API::rest_api_includes() when the WC version is 3.6 or greater. For WC older versions, loading the classes is not necessary, as they are always loaded by default.

Without this change, the following error happens when using the beta tester plugin with WC < 3.6:

```
Fatal error: Uncaught Error: Call to private method WC_API::rest_api_includes() from context 'WC_Beta_Tester_Admin_Menus' in /srv/www/wc-beta-tester/htdocs/wp-content/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-admin-menus.php on line 161
```

Related #50

cc @timmyc @claudiosanches 