### PR TITLE
add right margin to version modal header

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,3 @@
+.plugins_page_wc-beta-tester-version-picker .wc-backbone-modal-main .wc-backbone-modal-header h1 {
+	margin: 0 35px 0 0;
+}

--- a/includes/class-wc-beta-tester-admin-assets.php
+++ b/includes/class-wc-beta-tester-admin-assets.php
@@ -26,7 +26,8 @@ class WC_Beta_Tester_Admin_Assets {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		// Need admin styles for the modal.
-		wp_enqueue_style( 'woocommerce_admin_styles' );
+		wp_register_style( 'wc-beta-tester-admin', WC_Beta_Tester::instance()->plugin_url() . '/assets/css/admin.css', array( 'woocommerce_admin_styles' ) );
+		wp_enqueue_style( 'wc-beta-tester-admin' );
 
 		wp_register_script( 'wc-beta-tester-version-info', WC_Beta_Tester::instance()->plugin_url() . '/assets/js/version-information' . $suffix . '.js', array( 'wc-backbone-modal' ), WC_BETA_TESTER_VERSION );
 		wp_register_script( 'wc-beta-tester-version-picker', WC_Beta_Tester::instance()->plugin_url() . '/assets/js/version-picker' . $suffix . '.js', array( 'wc-backbone-modal' ), WC_BETA_TESTER_VERSION );


### PR DESCRIPTION
Closes #61 

This PR adds a right margin to the switch version modal to ensure it wraps to multiple lines before the close icon.

### Testing Instructions

- Use the developer tools in your browser to emulate a mobile phone screen size.
- Use the dev tools to adjust the font size of the header to change where the header wraps:

<img width="1330" alt="Screen Shot 2020-09-22 at 1 47 40 PM" src="https://user-images.githubusercontent.com/343847/93912535-4346b980-fcda-11ea-9be7-a7f129a84859.png">
<img width="1324" alt="Screen Shot 2020-09-22 at 1 47 57 PM" src="https://user-images.githubusercontent.com/343847/93912549-4772d700-fcda-11ea-9ffb-d444980228fc.png">


