### PR TITLE
only show activate WooCommerce button when WC is installed in default location

### DIFF
--- a/includes/views/html-admin-missing-woocommerce.php
+++ b/includes/views/html-admin-missing-woocommerce.php
@@ -19,7 +19,12 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) && current_user_can( 'activate_plugin', 'woocommerce/woocommerce.php' ) ) : ?>
 		<p>
+			<?php
+			$installed_plugins = get_plugins();
+			if ( isset( $installed_plugins['woocommerce/woocommerce.php'] ) ) :
+			?>
 			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce/woocommerce.php&plugin_status=active' ), 'activate-plugin_woocommerce/woocommerce.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Activate WooCommerce', 'woocommerce-beta-tester' ); ?></a>
+			<?php endif; ?>
 			<?php if ( current_user_can( 'deactivate_plugin', 'woocommerce-beta-tester/woocommerce-beta-tester.php' ) ) : ?>
 				<a href="<?php echo esc_url( wp_nonce_url( 'plugins.php?action=deactivate&plugin=woocommerce-beta-tester/woocommerce-beta-tester.php&plugin_status=inactive', 'deactivate-plugin_woocommerce-beta-tester/woocommerce-beta-tester.php' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Turn off Beta Tester plugin', 'woocommerce-beta-tester' ); ?></a>
 			<?php endif; ?>


### PR DESCRIPTION
Closes #62 

This PR adds a check for WooCommerce being installed in the default location to the WooCommerce not active notice. The Activate WooCommerce button is only shown if WooCommerce is detected.

### Testing Instructions

- Deactivate all plugins
- Ensure WooCommerce is installed
- On the plugins screen activate this plugin
- You should see the error notice with buttons for activating WC or deactivating this plugin
- Move the `plugins/woocommerce` folder to `plugins/wc`
- Refresh the browser screen
- Only the deactivate button should be shown