### PR TITLE
update bug report url to work with latest WC versions

### DIFF
--- a/includes/class-wc-beta-tester-admin-menus.php
+++ b/includes/class-wc-beta-tester-admin-menus.php
@@ -152,16 +152,20 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 	 * @return string
 	 */
 	protected function construct_ssr() {
+		if ( version_compare( WC()->version, '3.6', '<' ) ) {
+			return '';
+		}
+
 		$transient_name = 'wc-beta-tester-ssr';
 		$ssr            = get_transient( $transient_name );
 
 		if ( false === $ssr ) {
 			// When running WC 3.6 or greater it is necessary to manually load the REST API classes.
-			if ( version_compare( WC()->version, '3.6', '>=' ) && ! did_action( 'rest_api_init' ) ) {
+			if ( ! did_action( 'rest_api_init' ) ) {
 				WC()->api->rest_api_includes();
 			}
 
-			if ( ! class_exists( 'WC_REST_System_Status_Controller', false ) ) {
+			if ( ! class_exists( 'WC_REST_System_Status_Controller' ) ) {
 				return '';
 			}
 
@@ -184,10 +188,7 @@ Copy and paste the system status report from **WooCommerce > System Status** in 
 			$ssr = '';
 			foreach ( $response['environment'] as $key => $value ) {
 				$index = $key;
-				// @todo remove this hack after fix schema in WooCommerce, and Claudio never let you folks forget that need to write schema first, and review after every change, schema is the most important part of the REST API.
-				if ( 'version' === $index ) {
-					$index = 'wc_version';
-				} elseif ( 'external_object_cache' === $index ) {
+				if ( 'external_object_cache' === $index ) {
 					$ssr .= sprintf( "%s: %s\n", 'External object cache', wc_bool_to_string( $value ) );
 					continue;
 				}

--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -426,6 +426,11 @@ class WC_Beta_Tester {
 		unset( $releases['trunk'] );
 
 		$releases = array_keys( $releases );
+		foreach ( $releases as $index => $version ) {
+			if ( version_compare( $version, '3.6', '<' ) ) {
+				unset( $releases[ $index ] );
+			}
+		}
 
 		if ( 'beta' === $channel ) {
 			$releases = array_filter( $releases, array( __CLASS__, 'is_in_beta_channel' ) );

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -7,9 +7,9 @@
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4
- * Tested up to: 4.9
- * WC requires at least: 3.0.0
- * WC tested up to: 3.5.0
+ * Tested up to: 5.5
+ * WC requires at least: 3.6.0
+ * WC tested up to: 4.6.0
  * Text Domain: woocommerce-beta-tester
  *
  * @package WC_Beta_Tester

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -7,9 +7,9 @@
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4
- * Tested up to: 5.5
+ * Tested up to: 5.6
  * WC requires at least: 3.6.0
- * WC tested up to: 4.6.0
+ * WC tested up to: 4.8.0
  * Text Domain: woocommerce-beta-tester
  *
  * @package WC_Beta_Tester


### PR DESCRIPTION
Closes #67 

This PR
- Updates minimum WC version to 3.6
- Updates tested to versions to latest WC and WP
- Updates WC API usage to recent WC versions

### Testing

- Navigate to a WC page after switching to this branch
- Click Admin Bar -> WC Beta Tester -> Submit bug report
- This should open a new tab with the issue template pre-populated including the SSR