### PR TITLE
fix auto_update_plugin filter reference

### DIFF
--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -86,7 +86,7 @@ class WC_Beta_Tester {
 		);
 
 		add_filter( "plugin_action_links_{$this->plugin_name}", array( $this, 'plugin_action_links' ), 10, 1 );
-		add_filter( 'auto_update_plugin', 'auto_update_woocommerce', 100, 2 );
+		add_filter( 'auto_update_plugin', array( $this, 'auto_update_woocommerce' ), 100, 2 );
 
 		if ( 'stable' !== $this->get_settings()->channel ) {
 			add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );


### PR DESCRIPTION
Closes #69 

This PR fixes the filter reference for the `auto_update_plugin` to include the class object.

### Testing instructions

- Update to PHP 7.4
- In `master` load the plugins page. There will be one debug warning for each plugin listed
- Switch to this branch.
- Reload the page. There should be no new warnings.