### PR TITLE
Fixes "Notice: Undefined variable: item"

### DIFF
--- a/includes/class-wc-beta-tester.php
+++ b/includes/class-wc-beta-tester.php
@@ -343,7 +343,7 @@ class WC_Beta_Tester {
 	 * @return bool
 	 */
 	public function auto_update_woocommerce( $update, $plugin ) {
-		if ( true === $this->get_settings()->auto_update && 'woocommerce' === $item->slug ) {
+		if ( true === $this->get_settings()->auto_update && 'woocommerce' === $plugin->slug ) {
 			return true;
 		} else {
 			return $update;


### PR DESCRIPTION
Fixes "Notice: Undefined variable: item" when running the WC_Beta_Tester auto_update_woocommerce method on the wp-admin plugins.php file

Closes #75 