### PR TITLE
tag version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/woocommerce/woocommerce-beta-tester.git"
   },
   "title": "WooCommerce Beta Tester",
-  "version": "1.0.0",
+  "version": "2.0.2",
   "homepage": "http://github.com/woocommerce/woocommerce-beta-tester",
   "devDependencies": {
     "clean-css-cli": "^4.2.1",

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Beta Tester ===
-Contributors: automattic, bor0, claudiosanches, claudiulodro, kloon, mikejolley, peterfabian1000, rodrigosprimo
+Contributors: automattic, bor0, claudiosanches, claudiulodro, kloon, mikejolley, peterfabian1000, rodrigosprimo, wpmuguru
 Tags: woocommerce, woo commerce, beta, beta tester, bleeding edge, testing
 Requires at least: 4.7
-Tested up to: 5.2
+Tested up to: 5.6
 Stable tag: 2.0.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -52,6 +52,14 @@ Join in on our [GitHub repository](https://github.com/woocommerce/woocommerce/).
 See our [contributing guidelines here](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md).
 
 == Changelog ==
+
+= 2.0.2 =
+
+* Fix notice for undefined `item`
+* Fix auto_update_plugin filter reference
+* Fix including SSR in bug report
+* Fix style in version modal header
+* Add check for WooCommerce installed in default location
 
 = 2.0.1 =
 * Changes to make this plugin compatible with the upcoming WooCommerce 3.6

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Beta Tester
  * Plugin URI: https://github.com/woocommerce/woocommerce-beta-tester
  * Description: Run bleeding edge versions of WooCommerce. This will replace your installed version of WooCommerce with the latest tagged release - use with caution, and not on production sites.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4
@@ -23,7 +23,7 @@ if ( ! defined( 'WC_BETA_TESTER_FILE' ) ) {
 }
 
 if ( ! defined( 'WC_BETA_TESTER_VERSION' ) ) {
-	define( 'WC_BETA_TESTER_VERSION', '2.0.1' );
+	define( 'WC_BETA_TESTER_VERSION', '2.0.2' );
 }
 
 /**


### PR DESCRIPTION
This PR bumps the version and updates the readme in prep for release on WordPress.org.

Draft release: https://github.com/woocommerce/woocommerce-beta-tester/releases/edit/untagged-707da68f1f6daef0bf0d