### PR TITLE
add .distignore to exclude package files from zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,9 @@
+.editorconfig
+.gitignore
+.travis.yml
+.wordpress-org/
+composer.json
+composer.lock
+package-lock.json
+package.json
+phpcs.xml


### PR DESCRIPTION
This PR creates a `/distignore` to exclude pproject files from the zip generated by Github releases.

Closes #85