### PR TITLE
Add support for Woorelease

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,9 @@
+.editorconfig
+.gitignore
+.travis.yml
+.wordpress-org/
+composer.json
+composer.lock
+package-lock.json
+package.json
+phpcs.xml

--- a/.distignore
+++ b/.distignore
@@ -1,9 +1,17 @@
+.distignore
 .editorconfig
 .gitignore
 .travis.yml
+.git/
 .wordpress-org/
 composer.json
 composer.lock
 package-lock.json
 package.json
 phpcs.xml
+
+# build files
+woocommerce-beta-tester.zip
+node_modules/
+build/
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 node_modules/
+build/
+woocommerce-beta-tester.zip

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+PLUGIN_SLUG="woocommerce-beta-tester"
+PROJECT_PATH=$(pwd)
+BUILD_PATH="${PROJECT_PATH}/build"
+DEST_PATH="$BUILD_PATH/$PLUGIN_SLUG"
+
+echo "Generating build directory..."
+rm -rf "$BUILD_PATH"
+mkdir -p "$DEST_PATH"
+
+echo "Installing PHP and JS dependencies..."
+npm install
+echo "Running JS Build..."
+npm run uglify
+
+echo "Syncing files..."
+rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PATH/" --delete --delete-excluded
+
+echo "Generating zip file..."
+cd "$BUILD_PATH" || exit
+zip -q -r "${PLUGIN_SLUG}.zip" "$PLUGIN_SLUG/"
+
+cd "$PROJECT_PATH" || exit
+mv "$BUILD_PATH/${PLUGIN_SLUG}.zip" "$PROJECT_PATH"
+echo "${PLUGIN_SLUG}.zip file generated!"
+
+echo "Build done!"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+== Changelog ==

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "scripts": {
-    "build": "npm run uglify && npm run less",
+    "build": "./bin/build-zip.sh",
     "preuglify": "rm -f $npm_package_assets_js_min",
     "uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
     "preless": "rm -f $npm_package_assets_styles_css",
@@ -35,5 +35,8 @@
   "engines": {
     "node": ">=6.8.1",
     "npm": ">=4.0.5"
+  },
+  "config": {
+    "wp_org_slug": "woocommerce-beta-tester"
   }
 }


### PR DESCRIPTION
Closes #81 
Closes #85 

Supersedes #87

This PR adds support for publishing releases with Woorelease:

- Adds a `.distignore` for excluding files from the zip generation
- Adds build files to `.gitignore`
- Adds a build script (modified version if the `woocommerce` build script)
- Adds an empty `changelog.txt`
- Removes `scss` processing from the build script as the project doesn't have any `.scss` files

### Testing

- Run `npm install`
- Run `npm run build`
- The build should create `woocommerce-beta-tester.zip` in the root of the repo
- Install and activate the zip in a test install
- Verify beta tester functionality works

The build script and changelog.txt both need to be merged before these changes can be tested with Woorelease.