### PR TITLE
add svn authorization configuration entry

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
 == Changelog ==
 
-2021-XX-XX - version 2.0.3
+2021-09-22 - version 2.0.3
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,4 @@
 == Changelog ==
+
+2021-XX-XX - version 2.0.3
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-beta-tester",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
       "*.min.js"
     ]
   },
-  "config": {
+  "woorelease": {
+    "svn_reauth": "true",
     "wp_org_slug": "woocommerce-beta-tester"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/woocommerce/woocommerce-beta-tester.git"
   },
   "title": "WooCommerce Beta Tester",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "homepage": "http://github.com/woocommerce/woocommerce-beta-tester",
   "devDependencies": {
     "eslint": "5.16.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, bor0, claudiosanches, claudiulodro, kloon, mikejolley,
 Tags: woocommerce, woo commerce, beta, beta tester, bleeding edge, testing
 Requires at least: 4.7
 Tested up to: 5.6
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -53,7 +53,7 @@ See our [contributing guidelines here](https://github.com/woocommerce/woocommerc
 
 == Changelog ==
 
-= 2.0.3 2021-x-x =
+= 2.0.3 - 2021-09-22 =
 
 
 = 2.0.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,9 @@ See our [contributing guidelines here](https://github.com/woocommerce/woocommerc
 
 == Changelog ==
 
+= 2.0.3 2021-x-x =
+
+
 = 2.0.2 =
 
 * Fix notice for undefined `item`

--- a/woocommerce-beta-tester.php
+++ b/woocommerce-beta-tester.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Beta Tester
  * Plugin URI: https://github.com/woocommerce/woocommerce-beta-tester
  * Description: Run bleeding edge versions of WooCommerce. This will replace your installed version of WooCommerce with the latest tagged release - use with caution, and not on production sites.
- * Version: 2.0.2
+ * Version: 2.0.3
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 4.4


### PR DESCRIPTION
Closes #98

This PR adds the svn authorization configuration entry for Woorelease. We will use this PR to bump the plugin version for re-release. There won't be any code changes in the release.

Note: on testing the published version I found that admin.css wasn't being enqueued on any pages. Created #101 to address this.

### Testing

- Download version 2.0.3 from [WordPress.org](https://wordpress.org/plugins/woocommerce-beta-tester/)
- Verify there are no 404 errors on `admin.css` logged in the browser console

### Changelog Entry

* Bump version to release version including `admin.css`.