### PR TITLE
Lower case string comparison for versions

### DIFF
--- a/includes/class-wc-beta-tester-version-picker.php
+++ b/includes/class-wc-beta-tester-version-picker.php
@@ -145,7 +145,7 @@ class WC_Beta_Tester_Version_Picker {
 
 			// Is this the current version?
 			if ( strcasecmp($tag_version, $this->current_version) === 0 ) {
-				$versions_html .= '<span class="wcbt-current-version">' . esc_html__( '&nbsp;Installed Version', 'woocommerce-beta-tester' ) . '</span>';
+				$versions_html .= '<span class="wcbt-current-version"><strong>' . esc_html__( '&nbsp;Installed Version', 'woocommerce-beta-tester' ) . '</strong></span>';
 			}
 
 			$versions_html .= '</label>';

--- a/includes/class-wc-beta-tester-version-picker.php
+++ b/includes/class-wc-beta-tester-version-picker.php
@@ -141,10 +141,10 @@ class WC_Beta_Tester_Version_Picker {
 		foreach ( $tags as $tag_version ) {
 
 			$versions_html .= '<li class="wcbt-version-li">';
-			$versions_html .= '<label><input type="radio" ' . checked( $tag_version, $this->current_version, false ) . ' value="' . esc_attr( $tag_version ) . '" name="wcbt_switch_to_version">' . $tag_version;
+			$versions_html .= '<label><input type="radio" ' . checked( strtolower($tag_version), strtolower($this->current_version), false ) . ' value="' . esc_attr( $tag_version ) . '" name="wcbt_switch_to_version">' . $tag_version;
 
 			// Is this the current version?
-			if ( $tag_version === $this->current_version ) {
+			if ( strcasecmp($tag_version, $this->current_version) === 0 ) {
 				$versions_html .= '<span class="wcbt-current-version">' . esc_html__( '&nbsp;Installed Version', 'woocommerce-beta-tester' ) . '</span>';
 			}
 


### PR DESCRIPTION
This PR introduces lower case checks as in some cases the installed WooCommerce version would come in with upper-case and would be compared on the lower-case (e.g. checking if `5.9.0-rc.2` equals `5.9.0-RC.2`. As a result, both the radio button wasn't selected and the Installed Version text wasn't showing.

Closes https://github.com/woocommerce/woocommerce-beta-tester/issues/104

## Test steps
1. Checkout this branch and run `npm run build` to generate a zip for the plugin
2. Install the plugin on a test site with WooCommerce already installed
3. Switch versions to a version with upper-case in the name, for example, `5.9.0-rc.2`
4. Verify the `5.9.0-rc.2` is selected and has the text `Installed Version` next to it
5. Compare these results on a version that doesn't include these changes (for example, the current version available on the [WordPress plugins site](https://wordpress.org/plugins/woocommerce-beta-tester/))

### Changelog entry

> Fix: make WC version comparison case insensitive